### PR TITLE
Prevent gdm-disable-wayland running on NVIDIA

### DIFF
--- a/debian/patches/pop_nvidia_wayland.patch
+++ b/debian/patches/pop_nvidia_wayland.patch
@@ -1,0 +1,12 @@
+Index: gdm3/data/61-gdm.rules.in
+===================================================================
+--- gdm3.orig/data/61-gdm.rules.in	2020-10-08 09:40:16.690134613 -0600
++++ gdm3/data/61-gdm.rules.in	2020-10-08 09:41:41.499830623 -0600
+@@ -1,6 +1,6 @@
+ # disable Wayland on Hi1710 chipsets
+ ATTR{vendor}=="0x19e5", ATTR{device}=="0x1711", RUN+="@libexecdir@/gdm-disable-wayland"
+ # disable Wayland when using the proprietary nvidia driver
+-DRIVER=="nvidia", RUN+="@libexecdir@/gdm-disable-wayland"
++#DRIVER=="nvidia", RUN+="@libexecdir@/gdm-disable-wayland"
+ # disable Wayland if modesetting is disabled
+ IMPORT{cmdline}="nomodeset", RUN+="@libexecdir@/gdm-disable-wayland"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -16,3 +16,4 @@ ubuntu/XSession-Use-x-terminal-emulator-as-fallback-instead-of-x.patch
 
 # Pop!_OS patches
 pop_prefer_pop_session_fallback.patch
+pop_nvidia_wayland.patch


### PR DESCRIPTION
gdm-disable-wayland wipes out existing configuration in `custom.conf` when it runs, which prevents automatic login from working.

Need confirmation if this affects focal as well.